### PR TITLE
support ignoring not_planned issue close

### DIFF
--- a/.github/workflows/issue2md.yml
+++ b/.github/workflows/issue2md.yml
@@ -7,7 +7,10 @@ jobs:
   issue2md:
     runs-on: ubuntu-latest
     name: Convert closed issue to markdown with published action
-    if: ${{ !contains(github.event.issue.labels.*.name, 'test') }}
+    if: |
+      ${{
+        !contains(github.event.issue.labels.*.name, 'test') && github.event.issue.state_reason == 'completed'
+      }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test-issue2md.yml
+++ b/.github/workflows/test-issue2md.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Convert closed issue to markdown with test action
     # make sure kicking this workflow when issue has `test` label 
-    if: ${{ contains(github.event.issue.labels.*.name, 'test') }}
+    if: |
+      ${{
+        contains(github.event.issue.labels.*.name, 'test') && github.event.issue.state_reason == 'completed'
+      }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/docs/issue2md.yml
+++ b/docs/issue2md.yml
@@ -7,6 +7,8 @@ jobs:
   issue2md:
     runs-on: ubuntu-latest
     name: convert closed issue to markdown
+    # when state_reason is `not_planned` this action does not proceed
+    if: ${{ github.event.issue.state_reason == 'completed' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- solves: #7

## What
<!-- What features are added in this PR -->
- added conditional `github.event.issue.state_reason == 'completed'` to github action template

## QA, Evidence
<!-- Things that support this PR is correct -->
- I used other repo for testing how github action works. ref: https://github.com/go-zen-chu/github-action-checker/issues/1#issuecomment-1373179943
