### PR TITLE
Add duplicate markdown check option (check-dups)

### DIFF
--- a/.github/workflows/issue2md-check-dups.yml
+++ b/.github/workflows/issue2md-check-dups.yml
@@ -16,6 +16,7 @@ jobs:
           issue-url: ${{ github.event.issue.html_url }}
           # By default, this action stores markdown to repository root. If you want to change export dir, make directory and change setting below.
           export-dir: ./issues
+          check-dups: true
       - name: Send custom JSON data to Slack when issue2md failed
         if: failure()
         id: slack

--- a/.github/workflows/issue2md-check-dups.yml
+++ b/.github/workflows/issue2md-check-dups.yml
@@ -1,0 +1,40 @@
+# actual working sample for dogfooding using latest issue2md
+name: issue2md-check-dups
+on:
+  - push
+jobs:
+  issue2md:
+    runs-on: ubuntu-latest
+    name: Check same issueURL markdown exists in export-dir
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Convert issue to markdown
+        uses: go-zen-chu/issue2md@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-url: ${{ github.event.issue.html_url }}
+          # By default, this action stores markdown to repository root. If you want to change export dir, make directory and change setting below.
+          export-dir: ./issues
+      - name: Send custom JSON data to Slack when issue2md failed
+        if: failure()
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "text": ":warning: GitHub Action build result: ${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "GitHub Action build result: ${{ job.status }}\nActions URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          # currently, it is set to my personal slack channel
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/issue2md-check-dups.yml
+++ b/.github/workflows/issue2md-check-dups.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Convert issue to markdown
-        uses: go-zen-chu/issue2md@main
+        uses: ./tests/
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-url: ${{ github.event.issue.html_url }}

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,10 @@ inputs:
   # optional
   debug:
     description: "Run issue2md with debug mode"
-    default: false
+    default: "false"
+  check-dups:
+    description: "Find duplicate issueURL markdowns exists"
+    default: "false"
 runs:
   using: "docker"
   image: "docker://amasuda/issue2md:latest"
@@ -25,6 +28,7 @@ runs:
     - -issue-url=${{ inputs.issue-url }}
     - -export-dir=${{ inputs.export-dir }}
     - -debug=${{ inputs.debug }}
+    - -check-dups=${{ inputs.check-dups }}
 branding:
   icon: "book"
   color: "blue"

--- a/cmd/issue2md/main.go
+++ b/cmd/issue2md/main.go
@@ -26,10 +26,21 @@ func run(
 	if err := r.Run(func(c config.Config) error {
 		ghClient := genGitHubClient(c)
 		i2muc := ui2m.NewIssue2mdUseCase(ghClient, c.GetExportDir())
-		if err := i2muc.Convert2md(c.GetGitHubIssueURL()); err != nil {
-			return fmt.Errorf("convert to markdown: %w", err)
+		if c.GetCheckDups() {
+			res, err := i2muc.CheckDuplicateIssueFile()
+			if len(res) == 0 {
+				res = "No duplicate issueURL markdown files :tada:"
+			}
+			fmt.Printf("[CheckDuplicateIssueURLFile] %s", res)
+			if err != nil {
+				fmt.Printf("error: %s", err)
+			}
+		} else {
+			if err := i2muc.Convert2md(c.GetGitHubIssueURL()); err != nil {
+				return fmt.Errorf("convert to markdown: %w", err)
+			}
+			log.Infof("Export issue %s to %s, succeeded\n", c.GetGitHubIssueURL(), c.GetExportDir())
 		}
-		log.Infof("Export issue %s to %s, succeeded\n", c.GetGitHubIssueURL(), c.GetExportDir())
 		return nil
 	}); err != nil {
 		return fmt.Errorf("while running: %w", err)

--- a/tests/action.yml
+++ b/tests/action.yml
@@ -16,7 +16,10 @@ inputs:
   # optional
   debug:
     description: "Run issue2md with debug mode"
-    default: false
+    default: "false"
+  check-dups:
+    description: "Find duplicate issueURL markdowns exists"
+    default: "false"
 runs:
   using: "docker"
   # test action uses current Dockerfile (not published image)
@@ -26,6 +29,7 @@ runs:
     - -issue-url=${{ inputs.issue-url }}
     - -export-dir=${{ inputs.export-dir }}
     - -debug=${{ inputs.debug }}
+    - -check-dups=${{ inputs.check-dups }}
 branding:
   icon: "book"
   color: "blue"

--- a/usecase/issue2md/issue2md.go
+++ b/usecase/issue2md/issue2md.go
@@ -12,6 +12,7 @@ import (
 
 type Issue2mdUseCase interface {
 	Convert2md(issueURL string) error
+	CheckDuplicateIssueFile() (string, error)
 }
 
 type issue2mdUsecase struct {
@@ -38,7 +39,7 @@ type fileMeta struct {
 }
 
 // Usecase for finding duplicate file in export-dir
-func (imu *issue2mdUsecase) FindDuplicateFile() (string, error) {
+func (imu *issue2mdUsecase) CheckDuplicateIssueFile() (string, error) {
 	files, err := os.ReadDir(imu.expDir)
 	if err != nil {
 		return "", fmt.Errorf("read dirs: %w", err)
@@ -71,15 +72,16 @@ func (imu *issue2mdUsecase) FindDuplicateFile() (string, error) {
 				frontMatter: yfm,
 				absPath:     absPath,
 			}
+			// unique issue markdown
 			continue
 		}
-		sb.WriteString("find duplicate issue files:\n")
+		sb.WriteString("Find duplicate issue files:\n")
 		sb.WriteString(fileDict[iurl].absPath)
-		sb.WriteString(": ")
+		sb.WriteString(", [Modified] ")
 		sb.WriteString(fileDict[iurl].finfo.ModTime().String())
 		sb.WriteString("\n")
 		sb.WriteString(absPath)
-		sb.WriteString(": ")
+		sb.WriteString(", [Modified] ")
 		sb.WriteString(fi.ModTime().String())
 		sb.WriteString("\n")
 	}


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- https://github.com/go-zen-chu/issue2md/issues/12

## What
<!-- What features are added in this PR -->
- Add command line flag `-check-dups` for checking same issueURL markdown file exists.

## QA, Evidence
<!-- Things that support this PR is correct -->
- https://github.com/go-zen-chu/issue2md/actions/runs/4690567039

test locally

```
$ go run cmd/issue2md/main.go -export-dir=./issues -check-dups                                                                                                                                                                           (git)-[add-duplicate-markdown-checker] 
[CheckDuplicateIssueURLFile] Find duplicate issue files:
/home/amasuda/ghq/github.com/go-zen-chu/issue2md/issues/test issue 2 this will be failed because same issue already exported as markdown.md, [Modified] 2023-04-12 00:19:44.605124076 +0900 JST
/home/amasuda/ghq/github.com/go-zen-chu/issue2md/issues/test issue.md, [Modified] 2023-03-25 22:33:15.886457674 +0900 JST
```